### PR TITLE
Reshuffle binaries and add features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,6 +253,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lber"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a749954d43fcfb8d4381aa0c6cf291065053e0590d622f4f830393a9bd8278a5"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "nom",
+]
+
+[[package]]
 name = "ldap3"
 version = "0.7.0-alpha.7"
 source = "git+https://github.com/inejge/ldap3.git?rev=2f88e03b9a7cd16b33a0a8feca9e472f593ca2e3#2f88e03b9a7cd16b33a0a8feca9e472f593ca2e3"
@@ -262,7 +273,31 @@ dependencies = [
  "futures",
  "futures-util",
  "lazy_static",
- "lber",
+ "lber 0.2.0 (git+https://github.com/inejge/ldap3.git?rev=2f88e03b9a7cd16b33a0a8feca9e472f593ca2e3)",
+ "log",
+ "maplit",
+ "native-tls",
+ "nom",
+ "percent-encoding",
+ "thiserror",
+ "tokio",
+ "tokio-tls",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "ldap3"
+version = "0.7.0-alpha.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59362583ad012bb451084b3783af37a260fa280a962bbe52fa73b14d2fc702d2"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "futures-util",
+ "lazy_static",
+ "lber 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log",
  "maplit",
  "native-tls",
@@ -279,7 +314,8 @@ dependencies = [
 name = "ldap3-issue47"
 version = "0.1.0"
 dependencies = [
- "ldap3",
+ "ldap3 0.7.0-alpha.7 (git+https://github.com/inejge/ldap3.git?rev=2f88e03b9a7cd16b33a0a8feca9e472f593ca2e3)",
+ "ldap3 0.7.0-alpha.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,13 +4,28 @@ version = "0.1.0"
 authors = ["Nicolas Bigaouette <nbigaouette@elementai.com>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-ldap3 = "0.7.0-alpha.7"
-# Same as ldap3's dependency
+ldap3orig = { version = "0.7.0-alpha.7", package = "ldap3", optional = true }
+ldap3fixed = { git = "https://github.com/inejge/ldap3", rev = '2f88e03b9a7cd16b33a0a8feca9e472f593ca2e3', package = "ldap3", optional = true }
 tokio = { version = "0.2", features = ["dns", "macros", "io-util", "stream", "sync", "tcp", "time", "uds"] }
 
+[features]
+default = []
+no-loop-fix = ["ldap3orig"]
+with-loop-fix = ["ldap3fixed"]
 
-[patch.crates-io]
-ldap3 = { git = 'https://github.com/inejge/ldap3.git', rev = '2f88e03b9a7cd16b33a0a8feca9e472f593ca2e3' }
+[[bin]]
+name = "ldap3-unbind-orig"
+path = "src/ldap3-unbind-orig.rs"
+
+[[bin]]
+name = "ldap3-unbind-fixed"
+path = "src/ldap3-unbind-fixed.rs"
+
+[[bin]]
+name = "ldap3-drop-orig"
+path = "src/ldap3-drop-orig.rs"
+
+[[bin]]
+name = "ldap3-drop-fixed"
+path = "src/ldap3-drop-fixed.rs"

--- a/src/ldap3-drop-fixed.rs
+++ b/src/ldap3-drop-fixed.rs
@@ -1,0 +1,30 @@
+use std::{env, time::Duration};
+
+use ldap3fixed::{LdapConnAsync, LdapConnSettings};
+
+#[tokio::main]
+async fn main() -> Result<(), ldap3fixed::result::LdapError> {
+    let url = env::var("LDAP3_ISSUE47_URL").unwrap();
+
+    loop {
+        println!("Establishing connection to {:?}...", url);
+
+        let timeout = Duration::from_secs(5);
+        let settings = LdapConnSettings::new()
+            .set_conn_timeout(timeout)
+            .set_no_tls_verify(true);
+
+        let (conn, ldap) = match LdapConnAsync::with_settings(settings, url.as_str()).await {
+            Ok((conn, ldap)) => (conn, ldap),
+            Err(e) => return Err(e),
+        };
+        let handle = tokio::spawn(async move { conn.drive().await.unwrap() });
+
+        println!("    Connection established. Dropping.");
+
+        drop(ldap);
+        handle.await.unwrap();
+
+        tokio::time::delay_for(Duration::from_millis(100)).await;
+    }
+}

--- a/src/ldap3-drop-orig.rs
+++ b/src/ldap3-drop-orig.rs
@@ -1,0 +1,29 @@
+use std::{env, time::Duration};
+
+use ldap3orig::{LdapConnAsync, LdapConnSettings};
+
+#[tokio::main]
+async fn main() -> Result<(), ldap3orig::result::LdapError> {
+    let url = env::var("LDAP3_ISSUE47_URL").unwrap();
+
+    loop {
+        println!("Establishing connection to {:?}...", url);
+
+        let timeout = Duration::from_secs(5);
+        let settings = LdapConnSettings::new()
+            .set_conn_timeout(timeout)
+            .set_no_tls_verify(true);
+
+        let (conn, ldap) = match LdapConnAsync::with_settings(settings, url.as_str()).await {
+            Ok((conn, ldap)) => (conn, ldap),
+            Err(e) => return Err(e),
+        };
+        let _handle = tokio::spawn(async move { conn.drive().await.unwrap() });
+
+        println!("    Connection established. Dropping.");
+
+        drop(ldap);
+
+        tokio::time::delay_for(Duration::from_millis(100)).await;
+    }
+}

--- a/src/ldap3-unbind-fixed.rs
+++ b/src/ldap3-unbind-fixed.rs
@@ -1,0 +1,30 @@
+use std::{env, time::Duration};
+
+use ldap3fixed::{LdapConnAsync, LdapConnSettings};
+
+#[tokio::main]
+async fn main() -> Result<(), ldap3fixed::result::LdapError> {
+    let url = env::var("LDAP3_ISSUE47_URL").unwrap();
+
+    loop {
+        println!("Establishing connection to {:?}...", url);
+
+        let timeout = Duration::from_secs(5);
+        let settings = LdapConnSettings::new()
+            .set_conn_timeout(timeout)
+            .set_no_tls_verify(true);
+
+        let (conn, mut ldap) = match LdapConnAsync::with_settings(settings, url.as_str()).await {
+            Ok((conn, ldap)) => (conn, ldap),
+            Err(e) => return Err(e),
+        };
+        let handle = tokio::spawn(async move { conn.drive().await.unwrap() });
+
+        println!("    Connection established. Dropping.");
+
+        ldap.unbind().await.unwrap();
+        handle.await.unwrap();
+
+        tokio::time::delay_for(Duration::from_millis(100)).await;
+    }
+}

--- a/src/ldap3-unbind-orig.rs
+++ b/src/ldap3-unbind-orig.rs
@@ -1,9 +1,9 @@
 use std::{env, time::Duration};
 
-use ldap3::{LdapConnAsync, LdapConnSettings};
+use ldap3orig::{LdapConnAsync, LdapConnSettings};
 
 #[tokio::main]
-async fn main() -> Result<(), ldap3::result::LdapError> {
+async fn main() -> Result<(), ldap3orig::result::LdapError> {
     let url = env::var("LDAP3_ISSUE47_URL").unwrap();
 
     loop {
@@ -18,14 +18,11 @@ async fn main() -> Result<(), ldap3::result::LdapError> {
             Ok((conn, ldap)) => (conn, ldap),
             Err(e) => return Err(e),
         };
-        let handle = tokio::spawn(async move { conn.drive().await.unwrap() });
+        let _handle = tokio::spawn(async move { conn.drive().await.unwrap() });
 
         println!("    Connection established. Dropping.");
 
         ldap.unbind().await.unwrap();
-        std::mem::drop(ldap);
-
-        handle.await.unwrap();
 
         tokio::time::delay_for(Duration::from_millis(100)).await;
     }


### PR DESCRIPTION
See the commit message for details of the change. After this, the tests are invoked like so:

```
LDAP3_ISSUE47_URL=ldaps://whatever.local cargo run --quiet --features no-loop-fix --bin ldap3-unbind-orig
```
or
```
LDAP3_ISSUE47_URL=ldaps://whatever.local cargo run --quiet --features with-loop-fix --bin ldap3-unbind-fixed
```
or
```
LDAP3_ISSUE47_URL=ldaps://whatever.local cargo run --quiet --features no-loop-fix --bin ldap3-drop-orig
```
or
```
LDAP3_ISSUE47_URL=ldaps://whatever.local cargo run --quiet --features with-loop-fix --bin ldap3-drop-fixed
```

The third combo (no-loop-fix, drop-orig) is the only one triggering the leak.