### PR TITLE
Fix Rust toolchain file path in provisioning script

### DIFF
--- a/windows/Vagrantfile
+++ b/windows/Vagrantfile
@@ -1,13 +1,32 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
+# To install on Ubuntu 18.04.x LTS from scratch:
+#
+#   sudo apt install virtualbox
+#   sudo apt install vagrant
+#   sudo gem install winrm
+#   sudo gem install winrm-elevated
+#
+# Vagrantfile, four *.ps1 files, and the image file (see the next section) should
+# be in the same directory before executing "vagrant up".
+#
+# On some machines, Intel VT-x virtualization extensions, which Virtualbox needs,
+# are disabled by default, and must be enabled in the BIOS setup. If you're unsure
+# of VT-x status, reboot and check the BIOS settings.
+
 Vagrant.configure("2") do |config|
+  # The box is created from the Vagrant archive downloaded from Microsoft at
+  # <https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/>. At the time
+  # of writing, the image file in the archive is called "MSEdge - Win10.box". Unpack
+  # the archive in the directory with the Vagrantfile.
+  #
   # To create this box:
   #   vagrant box add \
   #     --checksum 8896d48cb1c63c53d3e6484bba0a7a539818cf855dab7aeacabc243f004d7f63 \
   #     --checksum-type sha256 \
   #     windows10_x64_1809 \
-  #     MSEdgeWin10.box
+  #     MSEdge\ -\ Win10.box
   config.vm.box = "windows10_x64_1809"
 
   config.vm.hostname = "ldap3-issue47"

--- a/windows/provision_rust.ps1
+++ b/windows/provision_rust.ps1
@@ -25,7 +25,7 @@ $downloadUrl = "https://dev-static.rust-lang.org/rustup/archive/$rustupVersion/$
 
 $setupFullPath = "$provisioningDirectory\$setupFilename"
 
-$toolchainFile = Resolve-Path "$PSScriptRoot\..\rust-toolchain"
+$toolchainFile = Resolve-Path "$PSScriptRoot\rust-toolchain"
 
 $toolchainVersion = Get-Content -Path $toolchainFile
 


### PR DESCRIPTION
I like your Vagrant VM provisioning script a lot, it makes it really easy to set up a Windows environment for cross-platform Rust testing. When using it, I noticed:

1. The VM image in Microsoft's archive is called `MSEdge - Win10.box`, but `Vagrantfile` expects `windows10_x64_1809`.

2. On Ubuntu 18.04 I had to run `sudo gem install winrm` and `sudo gem install winrm-elevated` in addition to installing Vagrant.

The provisioning scripts did everything but installing Rust. When running `provision_rust.ps1`, I got the error which said, among other things:

```
Resolve-Path : Cannot find path 'C:\rust-toolchain' because it does not exist.
At C:\provisioning\provision_rust.ps1:28 char:18
```

I think that `rust-toolchain` gets copied to `C:\provisioning`, not `C:\`. This PR addresses that.